### PR TITLE
Fix TypeOf[T] Issues

### DIFF
--- a/atomicbool.go
+++ b/atomicbool.go
@@ -1,0 +1,42 @@
+package events
+
+import (
+	"sync/atomic"
+)
+
+// atomic boolean alias leverages a 32-bit integer CAS
+type atomicbool int32
+
+// newAtomicBool creates an atomicbool with given default value
+func newAtomicBool(value bool) *atomicbool {
+	ab := new(atomicbool)
+	ab.Set(value)
+	return ab
+}
+
+// Loads the bool value atomically
+func (ab *atomicbool) Get() bool {
+	return atomic.LoadInt32((*int32)(ab)) != 0
+}
+
+// Sets the bool value atomically
+func (ab *atomicbool) Set(value bool) {
+	if value {
+		atomic.StoreInt32((*int32)(ab), 1)
+	} else {
+		atomic.StoreInt32((*int32)(ab), 0)
+	}
+}
+
+// CompareAndSet sets value to new if current is equal to the current value. If the new value is
+// set, this function returns true.
+func (ab *atomicbool) CompareAndSet(current, new bool) bool {
+	var o, n int32
+	if current {
+		o = 1
+	}
+	if new {
+		n = 1
+	}
+	return atomic.CompareAndSwapInt32((*int32)(ab), o, n)
+}

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -282,10 +282,10 @@ func (md *multicastDispatcher[T]) executeAsync(streams []*asyncEventStream[T], e
 		go func(stream *asyncEventStream[T]) {
 			defer func() {
 				if r := recover(); r != nil {
-					// FIXME: This will happen if events for the stream are queued and the stream is then closed.
-					// FIXME: Occurs due to a conflict caused by our design (allowing handlers to be externally
-					// FIXME: closed, which breaks go channel principles). We should look into a way to maintain
-					// FIXME: go principles and maintain our API.
+					// NOTE: This will happen if events for the stream are queued and the stream is then closed.
+					// NOTE: Occurs due to a conflict caused by our design (allowing handlers to be externally
+					// NOTE: closed, which breaks go channel principles). We should look into a way to maintain
+					// NOTE: go principles and maintain our API.
 				}
 			}()
 
@@ -312,10 +312,10 @@ func (md *multicastDispatcher[T]) executeSync(streams []*asyncEventStream[T], ev
 		go func(stream *asyncEventStream[T]) {
 			defer func() {
 				if r := recover(); r != nil {
-					// FIXME: This will happen if events for the stream are queued and the stream is then closed.
-					// FIXME: Occurs due to a conflict caused by our design (allowing handlers to be externally
-					// FIXME: closed, which breaks go channel principles). We should look into a way to maintain
-					// FIXME: go principles and maintain our API.
+					// NOTE: This will happen if events for the stream are queued and the stream is then closed.
+					// NOTE: Occurs due to a conflict caused by our design (allowing handlers to be externally
+					// NOTE: closed, which breaks go channel principles). We should look into a way to maintain
+					// NOTE: go principles and maintain our API.
 				}
 				wg.Done()
 			}()

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -50,13 +50,15 @@ type Dispatcher[T any] interface {
 
 	// NewEventStream returns an asynchronous event stream that can be used to receive dispatched events.
 	NewEventStream() EventStream[T]
+
+	// CloseEventStreams closes all listening event streams and shuts down the dispatcher
+	CloseEventStreams()
 }
 
 // asyncEventStream contains the event stream channel and metadata
 type asyncEventStream[T any] struct {
-	m        sync.Mutex
-	stream   chan T
-	isClosed bool
+	stream chan T
+	closed *atomicbool
 }
 
 // Stream returns access to the event T channel where events will arrive.
@@ -66,27 +68,27 @@ func (aes *asyncEventStream[T]) Stream() <-chan T {
 
 // Close shuts down the event stream, closing the channel
 func (aes *asyncEventStream[T]) Close() {
-	aes.m.Lock()
-	defer aes.m.Unlock()
-	if aes.isClosed {
+	if !aes.closed.CompareAndSet(false, true) {
 		return
 	}
-	aes.isClosed = true
 
 	close(aes.stream)
 }
 
 // IsClosed is set to true if the event stream has been closed
 func (aes *asyncEventStream[T]) IsClosed() bool {
-	aes.m.Lock()
-	defer aes.m.Unlock()
-	return aes.isClosed
+	return aes.closed.Get()
 }
 
 // dispatchedEvent[T] is an event payload that is processed in the event dispatching loop.
 type dispatchedEvent[T any] struct {
 	event T
 	sent  chan struct{}
+}
+
+// closeEvent is used to communicate to the dispatcher to shutdown any existing event streams
+type closeEvent struct {
+	done chan struct{}
 }
 
 // eventStreamHandler[T] represents an event handler processor linked to an EventHandler[T]
@@ -99,22 +101,22 @@ type eventStreamHandler[T any] struct {
 // multicastDispatcher[T] is a channel based multicast dispatcher
 type multicastDispatcher[T any] struct {
 	in  chan *dispatchedEvent[T]
-	end chan struct{}
+	end chan *closeEvent
 
 	handlers    map[HandlerID]*eventStreamHandler[T]
 	handlerLock sync.Mutex
 
-	streams    []*asyncEventStream[T]
-	streamLock sync.Mutex
+	streams set[*asyncEventStream[T]]
 }
 
 // AddEventHandler adds a new event handler method that is called whenever an event T is dispatched. A
 // unique HandlerID is returned that can be used to remove the handler.
 func (md *multicastDispatcher[T]) AddEventHandler(handler EventHandler[T]) HandlerID {
+	handlerID := HandlerID(uuid.NewString())
 	stream := md.NewEventStream()
 
 	// create a new go routine event receive loop for the new event stream
-	go func() {
+	go func(id HandlerID) {
 		for event := range stream.Stream() {
 			err := md.executeHandler(handler, event)
 
@@ -124,9 +126,14 @@ func (md *multicastDispatcher[T]) AddEventHandler(handler EventHandler[T]) Handl
 				fmt.Fprintf(os.Stderr, "EventHandler Error: %s\n", err)
 			}
 		}
-	}()
 
-	handlerID := HandlerID(uuid.NewString())
+		// in the event the handler is stream is closed via the dispatcher, the
+		// handler will still exist, so we remove here instead
+		md.handlerLock.Lock()
+		delete(md.handlers, id)
+		md.handlerLock.Unlock()
+	}(handlerID)
+
 	sHandler := &eventStreamHandler[T]{
 		id:     handlerID,
 		stream: stream,
@@ -180,58 +187,68 @@ func (md *multicastDispatcher[T]) Dispatch(event T) {
 	}
 }
 
+// NewEventStream returns an asynchronous event stream that can be used to receive dispatched events.
 func (md *multicastDispatcher[T]) NewEventStream() EventStream[T] {
-	md.streamLock.Lock()
-	defer md.streamLock.Unlock()
-
 	aes := &asyncEventStream[T]{
-		isClosed: false,
-		stream:   make(chan T),
+		closed: newAtomicBool(false),
+		stream: make(chan T),
 	}
 
-	md.streams = append(md.streams, aes)
+	md.streams.Add(aes)
 	return aes
+}
+
+// CloseEventStreams closes all listening event streams and shuts down the dispatcher
+func (md *multicastDispatcher[T]) CloseEventStreams() {
+	done := make(chan struct{})
+	md.end <- &closeEvent{
+		done: done,
+	}
+	<-done
 }
 
 // newMulticastDispatcher creates a new Dispatcher[T]
 func newMulticastDispatcher[T any]() Dispatcher[T] {
 	in := make(chan *dispatchedEvent[T], 5)
-	end := make(chan struct{})
+	end := make(chan *closeEvent)
 
 	md := &multicastDispatcher[T]{
 		in:       in,
 		end:      end,
+		streams:  newSet[*asyncEventStream[T]](),
 		handlers: make(map[HandlerID]*eventStreamHandler[T]),
 	}
 
 	go func() {
 		for {
-			var evt *dispatchedEvent[T]
-
 			// Select on incoming event or a shutdown
 			select {
-			case evt = <-md.in:
-			case <-md.end:
-				md.streamLock.Lock()
-				for i := 0; i < len(md.streams); i++ {
-					md.streams[i].Close()
+			// incoming event
+			case evt := <-md.in:
+				// get the event streams to notify
+				streams := md.getEventStreams()
+				if len(streams) == 0 {
+					continue
 				}
-				md.streamLock.Unlock()
+
+				// check to see if the event sent over requires synchronization or not
+				if evt.sent == nil {
+					md.executeAsync(streams, evt)
+				} else {
+					md.executeSync(streams, evt)
+				}
+
+			// dispatcher closing
+			case closeEvt := <-md.end:
+				streams := md.streams.ToSlice()
+				for _, s := range streams {
+					s.Close()
+				}
+				md.streams.RemoveAll()
+				closeEvt.done <- struct{}{}
 				return
 			}
 
-			// get the event streams to notify
-			streams := md.getEventStreams()
-			if len(streams) == 0 {
-				continue
-			}
-
-			// check to see if the event sent over requires synchronization or not
-			if evt.sent == nil {
-				md.executeAsync(streams, evt)
-			} else {
-				md.executeSync(streams, evt)
-			}
 		}
 	}()
 
@@ -240,38 +257,17 @@ func newMulticastDispatcher[T any]() Dispatcher[T] {
 
 // getEventStreams returns an event stream list to notify.
 func (md *multicastDispatcher[T]) getEventStreams() []*asyncEventStream[T] {
-	md.streamLock.Lock()
-	if len(md.streams) == 0 {
-		md.streamLock.Unlock()
+	if md.streams.Length() == 0 {
 		return nil
 	}
 
 	// ensure that we remove all streams that are closed
-	// little note about this logic: we create a pointer to the
-	// same underlying array for ad.streams, then write only valid
-	// streams, then finally nil out any of the remaining indices
-	// and set the new streams pointer (it reuses the same memory to
-	// filter out closed streams)
-	validStreams := md.streams[:0]
-	for _, stream := range md.streams {
-		if !stream.IsClosed() {
-			validStreams = append(validStreams, stream)
-		}
-	}
+	md.streams.RemoveOn(func(stream *asyncEventStream[T]) bool {
+		return stream == nil || stream.IsClosed()
+	})
 
-	// nil out any leftover indexes, and update the slice
-	for i := len(validStreams); i < len(md.streams); i++ {
-		md.streams[i] = nil
-	}
-	md.streams = validStreams
-
-	// TODO: We should pool these scratch array copies so we don't have to
-	// TODO: allocate every time.
-	toNotify := make([]*asyncEventStream[T], len(md.streams))
-	copy(toNotify, md.streams)
-	md.streamLock.Unlock()
-
-	return toNotify
+	// return a slice containing the streams to dispatch to
+	return md.streams.ToSlice()
 }
 
 // executeAsync will create go routines to send the event to each stream and does not block
@@ -307,9 +303,17 @@ func (md *multicastDispatcher[T]) executeSync(streams []*asyncEventStream[T], ev
 	var wg sync.WaitGroup
 	wg.Add(length)
 
-	for i := 0; i < len(streams); i++ {
+	for i := 0; i < length; i++ {
 		go func(stream *asyncEventStream[T]) {
-			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					// FIXME: This will happen if events for the stream are queued and the stream is then closed.
+					// FIXME: Occurs due to a conflict caused by our design (allowing handlers to be externally
+					// FIXME: closed, which breaks go channel principles). We should look into a way to maintain
+					// FIXME: go principles and maintain our API.
+				}
+				wg.Done()
+			}()
 
 			if stream.IsClosed() {
 				return

--- a/events.go
+++ b/events.go
@@ -39,9 +39,9 @@ func typeOf[T any]() string {
 	return fmt.Sprintf("%s%s/%s", prefix, t.PkgPath(), t.Name())
 }
 
-// DispatcherFor[T] locates an existing global dispatcher for an event type, or creates a new one
+// GlobalDispatcherFor[T] locates an existing global dispatcher for an event type, or creates a new one
 // if one does not exist
-func DispatcherFor[T any]() Dispatcher[T] {
+func GlobalDispatcherFor[T any]() Dispatcher[T] {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -51,4 +51,9 @@ func DispatcherFor[T any]() Dispatcher[T] {
 	}
 
 	return dispatchers[key].(Dispatcher[T])
+}
+
+// NewDispatcher[T] creates a new multicast event dispatcher
+func NewDispatcher[T any]() Dispatcher[T] {
+	return newMulticastDispatcher[T]()
 }

--- a/events.go
+++ b/events.go
@@ -17,8 +17,24 @@ func init() {
 
 // typeOf is a utility that can covert a T type to a package + type name for generic types.
 func typeOf[T any]() string {
-	t := reflect.TypeOf(*new(T))
-	return fmt.Sprintf("%s/%s", t.PkgPath(), t.Name())
+	var inst T
+	var prefix string
+
+	// get a reflect.Type of a variable with type T
+	t := reflect.TypeOf(inst)
+
+	// pointer types do not carry the adequate type information, so we need to extract the
+	// underlying types until we reach the non-pointer type, we prepend a * each depth
+	for t != nil && t.Kind() == reflect.Ptr {
+		prefix += "*"
+		t = t.Elem()
+	}
+	if t == nil {
+		panic(fmt.Sprintf("Unable to generate a key for type: %+v", t))
+	}
+
+	// combine the prefix, package path, and the type name
+	return fmt.Sprintf("%s%s/%s", prefix, t.PkgPath(), t.Name())
 }
 
 // DispatcherFor[T] locates an existing global dispatcher for an event type, or creates a new one

--- a/events.go
+++ b/events.go
@@ -29,8 +29,10 @@ func typeOf[T any]() string {
 		prefix += "*"
 		t = t.Elem()
 	}
+
+	// this should not be possible, but in the event that it does, we want to be loud about it
 	if t == nil {
-		panic(fmt.Sprintf("Unable to generate a key for type: %+v", t))
+		panic(fmt.Sprintf("Unable to generate a key for type: %+v", reflect.TypeOf(inst)))
 	}
 
 	// combine the prefix, package path, and the type name

--- a/events.go
+++ b/events.go
@@ -8,11 +8,11 @@ import (
 
 var (
 	lock        sync.Mutex
-	dispatchers map[string]interface{}
+	dispatchers map[string]any
 )
 
 func init() {
-	dispatchers = make(map[string]interface{})
+	dispatchers = make(map[string]any)
 }
 
 // typeOf is a utility that can covert a T type to a package + type name for generic types.

--- a/events_test.go
+++ b/events_test.go
@@ -26,6 +26,18 @@ func waitChannelFor(wg *sync.WaitGroup) <-chan struct{} {
 	return ch
 }
 
+func strcmp[T comparable](t *testing.T, a, b T) {
+	if a != b {
+		t.Errorf("Expected %+v. Got: %+v", a, b)
+	}
+}
+
+func TestTypeOf(t *testing.T) {
+	strcmp(t, typeOf[TestEvent](), "github.com/kubecost/events/TestEvent")
+	strcmp(t, typeOf[*TestEvent](), "*github.com/kubecost/events/TestEvent")
+	strcmp(t, typeOf[**TestEvent](), "**github.com/kubecost/events/TestEvent")
+}
+
 func TestDispatchEventStream(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/set.go
+++ b/set.go
@@ -1,0 +1,128 @@
+package events
+
+import "sync"
+
+// set is an implementation prototype for a basic mathematical set data structure. It's API is geared more
+// towards a specific use inside the events package rather than a more general purpose use.
+type set[T comparable] interface {
+	// Adds an item to the set. If the item already exists, it is replaced.
+	Add(item T)
+
+	// Remove removes the item from the set if it exists, which returns true. If the item doesn't
+	// exist, false is returned.
+	Remove(item T) bool
+
+	// RemoveOn accepts a predicate that is run against each item, removing the item on a true
+	// return.
+	RemoveOn(func(T) bool)
+
+	// RemoveAll removes all of the items in the set
+	RemoveAll()
+
+	// Has returns true if the item exists within the set. Otherwise, false.
+	Has(item T) bool
+
+	// Length returns the total number of items in the set.
+	Length() int
+
+	// ToSlice creates a new slice of size Length(), copies the set elements into the slice, and
+	// returns it.
+	ToSlice() []T
+}
+
+// lockingSet is a thread-safe implementation of set which leverages a go map for storage.
+type lockingSet[T comparable] struct {
+	lock sync.Mutex
+	m    map[T]struct{}
+}
+
+// creates a new set for use with dispatching
+func newSet[T comparable]() set[T] {
+	return &lockingSet[T]{
+		m: make(map[T]struct{}),
+	}
+}
+
+// Adds an item to the set. If the item already exists, it is replaced.
+func (s *lockingSet[T]) Add(item T) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.m[item] = struct{}{}
+}
+
+// Remove removes the item from the set if it exists, which returns true. If the item doesn't
+// exist, false is returned.
+func (s *lockingSet[T]) Remove(item T) (ok bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	_, ok = s.m[item]
+
+	if !ok {
+		return
+	}
+
+	delete(s.m, item)
+	return
+}
+
+// RemoveOn accepts a predicate that is run against each item, removing the item on a true
+// return.
+func (s *lockingSet[T]) RemoveOn(predicate func(T) bool) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	for k := range s.m {
+		if predicate(k) {
+			delete(s.m, k)
+		}
+	}
+}
+
+// RemoveAll removes all of the items in the set
+func (s *lockingSet[T]) RemoveAll() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	for k := range s.m {
+		delete(s.m, k)
+	}
+}
+
+// Has returns true if the item exists within the set. Otherwise, false.
+func (s *lockingSet[T]) Has(item T) bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	_, ok := s.m[item]
+	return ok
+}
+
+// Length returns the total number of items in the set.
+func (s *lockingSet[T]) Length() int {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return len(s.m)
+}
+
+// ToSlice creates a new slice of size Length(), copies the set elements into the slice, and
+// returns it.
+func (s *lockingSet[T]) ToSlice() []T {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	l := len(s.m)
+	if l == 0 {
+		return nil
+	}
+
+	slice := make([]T, l)
+	index := 0
+	for k := range s.m {
+		slice[index] = k
+		index++
+	}
+	return slice
+}

--- a/set.go
+++ b/set.go
@@ -1,6 +1,9 @@
 package events
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // set is an implementation prototype for a basic mathematical set data structure. It's API is geared more
 // towards a specific use inside the events package rather than a more general purpose use.
@@ -28,6 +31,9 @@ type set[T comparable] interface {
 	// ToSlice creates a new slice of size Length(), copies the set elements into the slice, and
 	// returns it.
 	ToSlice() []T
+
+	// CopyTo accepts a destination slice and writes the contents of the set to it.
+	CopyTo([]T) error
 }
 
 // lockingSet is a thread-safe implementation of set which leverages a go map for storage.
@@ -125,4 +131,26 @@ func (s *lockingSet[T]) ToSlice() []T {
 		index++
 	}
 	return slice
+}
+
+// CopyTo accepts a destination slice and writes the contents of the set to it.
+func (s *lockingSet[T]) CopyTo(destination []T) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	l := len(s.m)
+	if l == 0 {
+		return nil
+	}
+
+	if len(destination) > l {
+		return fmt.Errorf("Destination length(%d) < source length (%d)", len(destination), l)
+	}
+
+	index := 0
+	for k := range s.m {
+		destination[index] = k
+		index++
+	}
+	return nil
 }


### PR DESCRIPTION
### Summary of Current Changes:
* Fix issue with `typeOf[T]()` that would not register pointer types correctly
* Optimization in `typeOf[T]` that avoids using `new(T)`
* Adding more improvements to the API while we're still in early development (breaking change) `DispatcherFor[T]` is now `GlobalDispatcherFor[T]`, and added a new instanced dispatcher creation via `NewDispatcher[T]`. 
* Improved some awkward data structure interactions and replaced some unnecessary locking with atomic flags. 
* Fixed an issue with tests, running them concurrently or even fast enough would leak previous test data into the next test. 

# Remaining Changes Required:
* Add some type of adapter or hook interface for logging and/or error reporting. 