### PR TITLE
Persistent Dispatchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ myEventDispatcher := events.NewDispatcher[MyEvent]()
 
 This will create a new dispatcher instance for the type `MyEvent`. Any events that dispatch over the instance will be received by any event handlers on that dispatcher only. Instanced dispatchers do not share event streams with the global dispatcher for that type. 
 
-Instanced dispatchers should also be closed when they are no longer needed. This will close any open event streams and remove any existing event handlers automatically. *NOTE*: Do not call `CloseEventStreams()` on a global dispatcher.
+Instanced dispatchers should also be closed when they are no longer needed. This will close any open event streams and remove any existing event handlers automatically. *NOTE:* Calling `CloseEventStreams()` on an instanced dispatcher will end that dispatchers lifecycle, disallowing any reuse. Calling `CloseEventStreams()` on a global dispatcher will remove all event handlers and close all event streams, but will not shutdown the dispatcher, and will allow it to be reused. 
 ```go
 type MyEvent struct {
     Message string 

--- a/events.go
+++ b/events.go
@@ -47,13 +47,19 @@ func GlobalDispatcherFor[T any]() Dispatcher[T] {
 
 	key := typeOf[T]()
 	if _, ok := dispatchers[key]; !ok {
-		dispatchers[key] = newMulticastDispatcher[T]()
+		dispatchers[key] = newMulticastDispatcher[T](true)
 	}
 
 	return dispatchers[key].(Dispatcher[T])
 }
 
+// Dispatch is a convenience method which dispatches an event on the global dispatcher for a specific
+// T event type.
+func Dispatch[T any](event T) {
+	GlobalDispatcherFor[T]().Dispatch(event)
+}
+
 // NewDispatcher[T] creates a new multicast event dispatcher
 func NewDispatcher[T any]() Dispatcher[T] {
-	return newMulticastDispatcher[T]()
+	return newMulticastDispatcher[T](false)
 }


### PR DESCRIPTION
* Added convenience global dispatch method: `events.Dispatch` 
* Added persistent flag, which is set on global dispatchers to prevent `CloseEventStreams()` from bricking the global dispatcher instance. 