### PR TITLE
DispatchSync and SyncStream Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ go func() {
 }()
 ```
 
-Then, this receiver will _always_ receive and handle events asynchronously. If you were dispatch an event using the `DispatchSync(...)` method on `Dispatcher`, the dispatcher will block *until the event is dispatched to the receiver*. However, what you wanted the `DispatchSync(...)` to block until the event is received and handled? For this, you will need to change the range loop in your handler slightly:
+Then, this receiver will _always_ receive and handle events asynchronously. If you were dispatch an event using the `DispatchSync(...)` method on `Dispatcher`, the dispatcher will block *until the event is dispatched to the receiver*. However, what if you wanted the `DispatchSync(...)` to block until the event is received and handled? For this, you will need to change the range loop in your handler slightly:
 
 ```go
 go func() {

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -542,7 +542,6 @@ func (md *multicastDispatcher[T]) executeSync(streams []*asyncEventStream[T], ev
 		go func(stream *asyncEventStream[T]) {
 			defer func() {
 				if r := recover(); r != nil {
-					fmt.Println("Panic!", r)
 					// This will happen if events for the stream are queued and the stream
 					// is then closed. Occurs due to a conflict caused by our design
 					// (allowing handlers to be externally closed, which breaks go channel

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -35,8 +35,7 @@ type EventStream[T any] interface {
 	Stream() <-chan T
 
 	// SyncStream returns a channel that receives SyncEvent[T] instances containing the
-	// event T payload and a channel to signal when the event is processed. This channel
-	// *ONLY* receives events that are dispatched with DispatchSync.
+	// event T payload and a channel to signal when the event is processed.
 	SyncStream() <-chan SyncEvent[T]
 
 	// Close shuts down the event stream, closing the channel

--- a/events.go
+++ b/events.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 )
 
 var (
@@ -30,7 +31,8 @@ func typeOf[T any]() string {
 		t = t.Elem()
 	}
 
-	// this should not be possible, but in the event that it does, we want to be loud about it
+	// this should not be possible, but in the event that it does, we want to be loud about
+	// it
 	if t == nil {
 		panic(fmt.Sprintf("Unable to generate a key for type: %+v", reflect.TypeOf(inst)))
 	}
@@ -39,8 +41,8 @@ func typeOf[T any]() string {
 	return fmt.Sprintf("%s%s/%s", prefix, t.PkgPath(), t.Name())
 }
 
-// GlobalDispatcherFor[T] locates an existing global dispatcher for an event type, or creates a new one
-// if one does not exist
+// GlobalDispatcherFor[T] locates an existing global dispatcher for an event type, or
+// creates a new one if one does not exist
 func GlobalDispatcherFor[T any]() Dispatcher[T] {
 	lock.Lock()
 	defer lock.Unlock()
@@ -53,10 +55,22 @@ func GlobalDispatcherFor[T any]() Dispatcher[T] {
 	return dispatchers[key].(Dispatcher[T])
 }
 
-// Dispatch is a convenience method which dispatches an event on the global dispatcher for a specific
-// T event type.
+// Dispatch is a convenience method which dispatches an event using the global dispatcher
+// for a specific T event type.
 func Dispatch[T any](event T) {
 	GlobalDispatcherFor[T]().Dispatch(event)
+}
+
+// DispatchSync is a convenience method which synchronously dispatches an event using the
+// global dispatcher for a specific T event type.
+func DispatchSync[T any](event T) {
+	GlobalDispatcherFor[T]().DispatchSync(event)
+}
+
+// Dispatch is a convenience method which synchronously dispatches an event with a timeout
+// using the global dispatcher for a specific T event type.
+func DispatchSyncWithTimeout[T any](event T, timeout time.Duration) {
+	GlobalDispatcherFor[T]().DispatchSyncWithTimeout(event, timeout)
 }
 
 // NewDispatcher[T] creates a new multicast event dispatcher

--- a/events_test.go
+++ b/events_test.go
@@ -42,14 +42,15 @@ type TypedEvent struct {
 	Message string
 }
 
-// waitAndDispatch sleeps for the specified duration, then dispatches the event using the provided
-// dispatcher
+// waitAndDispatch sleeps for the specified duration, then dispatches the event using the
+// provided dispatcher
 func waitAndDispatch[T any](dur time.Duration, dispatcher Dispatcher[T], event T) {
 	time.Sleep(dur)
 	dispatcher.Dispatch(event)
 }
 
-// waitChannelFor creates returns a channel that will send a signal when the waitgroup is done.
+// waitChannelFor creates returns a channel that will send a signal when the waitgroup is
+// done.
 func waitChannelFor(wg *sync.WaitGroup) <-chan struct{} {
 	ch := make(chan struct{})
 	go func() {
@@ -116,8 +117,8 @@ func TestSingleDispatcherMultipleHandlers(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	// for 10 events and 3 handlers, we'll expect to receive
-	// 30 total handler calls (10 events per handler)
+	// for 10 events and 3 handlers, we'll expect to receive 30 total handler calls (10
+	// events per handler)
 	wg.Add(3 * totalEvents)
 
 	d := NewDispatcher[TestEvent]()
@@ -279,9 +280,14 @@ func TestFilteredEventStreams(t *testing.T) {
 		stream := d.NewFilteredEventStream(eventFilter(TypedEventKindTwo))
 		wg.Done()
 
-		for event := range stream.Stream() {
-			atomic.AddUint32(&twoCount, 1)
-			t.Logf("Two Handler: [Event %s]\n", event.Message)
+		for syncEvent := range stream.SyncStream() {
+			func() {
+				defer syncEvent.Done()
+
+				event := syncEvent.Event
+				atomic.AddUint32(&twoCount, 1)
+				t.Logf("Two Handler: [Event %s]\n", event.Message)
+			}()
 		}
 	}()
 
@@ -291,9 +297,14 @@ func TestFilteredEventStreams(t *testing.T) {
 		stream := d.NewFilteredEventStream(eventFilter(TypedEventKindThree))
 		wg.Done()
 
-		for event := range stream.Stream() {
-			atomic.AddUint32(&threeCount, 1)
-			t.Logf("Three Handler: [Event %s]\n", event.Message)
+		for syncEvent := range stream.SyncStream() {
+			func() {
+				defer syncEvent.Done()
+
+				event := syncEvent.Event
+				atomic.AddUint32(&threeCount, 1)
+				t.Logf("Three Handler: [Event %s]\n", event.Message)
+			}()
 		}
 	}()
 
@@ -303,9 +314,14 @@ func TestFilteredEventStreams(t *testing.T) {
 		stream := d.NewFilteredEventStream(eventFilter(TypedEventKindThree))
 		wg.Done()
 
-		for event := range stream.Stream() {
-			atomic.AddUint32(&threeCount, 1)
-			t.Logf("Another Three Handler: [Event %s]\n", event.Message)
+		for syncEvent := range stream.SyncStream() {
+			func() {
+				defer syncEvent.Done()
+
+				event := syncEvent.Event
+				atomic.AddUint32(&threeCount, 1)
+				t.Logf("Another Three Handler: [Event %s]\n", event.Message)
+			}()
 		}
 	}()
 
@@ -315,9 +331,14 @@ func TestFilteredEventStreams(t *testing.T) {
 		stream := d.NewEventStream()
 		wg.Done()
 
-		for event := range stream.Stream() {
-			atomic.AddUint32(&anyCount, 1)
-			t.Logf("Universal Handler: [Event %s]\n", event.Message)
+		for syncEvent := range stream.SyncStream() {
+			func() {
+				defer syncEvent.Done()
+
+				event := syncEvent.Event
+				atomic.AddUint32(&anyCount, 1)
+				t.Logf("Universal Handler: [Event %s]\n", event.Message)
+			}()
 		}
 	}()
 
@@ -474,6 +495,100 @@ func TestGlobalDispatcherCloseAllAndReuse(t *testing.T) {
 	}
 
 	d.CloseEventStreams()
+}
+
+func TestSyncAndAsyncDispatch(t *testing.T) {
+	var totalHandled uint32 = 0
+
+	var wait sync.WaitGroup
+	wait.Add(2)
+
+	d := NewDispatcher[TestEvent]()
+
+	go func() {
+		wait.Done()
+
+		stream := d.NewEventStream()
+		for syncEvent := range stream.SyncStream() {
+			func() {
+				defer syncEvent.Done()
+				atomic.AddUint32(&totalHandled, 1)
+				t.Logf("Sync Receive: [%s]\n", syncEvent.Event.Message)
+			}()
+		}
+	}()
+
+	go func() {
+		wait.Done()
+
+		stream := d.NewEventStream()
+		for evt := range stream.Stream() {
+			atomic.AddUint32(&totalHandled, 1)
+			t.Logf("Async Receive: [%s]\n", evt.Message)
+		}
+	}()
+
+	wait.Wait()
+
+	for i := 0; i < 3; i++ {
+		if i != 1 {
+			d.Dispatch(TestEvent{Message: fmt.Sprintf("Regular Event: %d", i)})
+		} else {
+			d.DispatchSync(TestEvent{Message: fmt.Sprintf("Sync Event: %d", i)})
+		}
+	}
+
+	time.Sleep(1 * time.Second)
+	if totalHandled != 6 {
+		t.Errorf("Total Handled != 6. Got: %d\n", totalHandled)
+	}
+}
+
+func TestDispatchSyncWithTimeout(t *testing.T) {
+	var complete sync.WaitGroup
+	complete.Add(1)
+
+	d := NewDispatcher[TestEvent]()
+
+	go func() {
+		defer complete.Done()
+
+		es := d.NewEventStream()
+		for syncEvent := range es.SyncStream() {
+			t.Logf("I messed up and forgot to call Done() on the sync event: %s!\n", syncEvent.Event.Message)
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	d.DispatchSyncWithTimeout(TestEvent{Message: "Test"}, time.Second)
+	d.CloseEventStreams()
+
+	select {
+	case <-waitChannelFor(&complete):
+		t.Logf("Completed successfully\n")
+		return
+	case <-time.After(3 * time.Second):
+		t.Errorf("Test failed. Timed out after 3 seconds\n")
+	}
+}
+
+func TestDispatchSyncNoReceivers(t *testing.T) {
+	d := NewDispatcher[TestEvent]()
+
+	complete := make(chan struct{})
+	go func() {
+		d.DispatchSync(TestEvent{Message: "Test"})
+		complete <- struct{}{}
+	}()
+
+	select {
+	case <-complete:
+		t.Logf("Completed successfully\n")
+		return
+	case <-time.After(1 * time.Second):
+		t.Errorf("Test failed. Timed out after 1 second\n")
+	}
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
* Added functionality for Synchronous Dispatching 
* Added `WithTimeout` support for dispatching synchronous events with bounds. 
* Fixed bug where calling `CloseEventStreams()` after calling `DispatchSync(...)` would result in deadlock. 
* Fixed multiple bugs related to dispatching to event streams which were not being read from.
  * Calling `NewEventStream()` on a dispatcher without reading from the `Stream` would leak go routines each time `Dispatch` was called. 
  * Calling `NewEventStream()` on a dispatcher without reading from the `Stream` would deadlock if `DispatchSync` was called.